### PR TITLE
Bug/ignore commented review state

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -131,7 +131,12 @@ func normalizedReviews(reviews []*github.PullRequestReview) []Review {
 	// Reviews are in chronological order, overwrite previous reviews of the same user.
 	statePerUser := make(map[int64]Review)
 	for _, review := range reviews {
-		statePerUser[review.GetUser().GetID()] = reviewLookupTable[strings.ToLower(review.GetState())]
+		state := reviewLookupTable[strings.ToLower(review.GetState())]
+
+		// Ignore the commented state, as they aren't actual reviews.
+		if state != Commented {
+			statePerUser[review.GetUser().GetID()] = state
+		}
 	}
 
 	states := make([]Review, 0, len(statePerUser))

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -92,13 +92,11 @@ func TestNormalizedReviews(t *testing.T) {
 				&github.PullRequestReview{State: &approved, User: &github.User{ID: int64ToPtr(1)}},
 				&github.PullRequestReview{State: &changesRequested, User: &github.User{ID: int64ToPtr(2)}},
 				&github.PullRequestReview{State: &dismissed, User: &github.User{ID: int64ToPtr(3)}},
-				&github.PullRequestReview{State: &commented, User: &github.User{ID: int64ToPtr(4)}},
 			},
 			expected: []Review{
 				Approved,
 				ChangesRequested,
 				Dismissed,
-				Commented,
 			},
 		},
 		{
@@ -113,6 +111,18 @@ func TestNormalizedReviews(t *testing.T) {
 			expected: []Review{
 				Approved,
 				Approved,
+			},
+		},
+		{
+			name: "Ignores comment reviews",
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{State: &changesRequested, User: &github.User{ID: int64ToPtr(1)}},
+				&github.PullRequestReview{State: &commented, User: &github.User{ID: int64ToPtr(1)}},
+				&github.PullRequestReview{State: &commented, User: &github.User{ID: int64ToPtr(2)}},
+				&github.PullRequestReview{State: &commented, User: &github.User{ID: int64ToPtr(1)}},
+			},
+			expected: []Review{
+				ChangesRequested,
 			},
 		},
 	}


### PR DESCRIPTION
Github adds extra `COMMENTED` reviews for all new comments. This causes issues when determining the actual state of the most recent review of a user.

This can also further exasperate the lack of paging, so I implemented the paging logic on the reviews list call.